### PR TITLE
avoid mgutils initing noises for every get_level_at_point() call

### DIFF
--- a/mgutils/mg_v7.lua
+++ b/mgutils/mg_v7.lua
@@ -66,7 +66,7 @@ local intialized = false
 
 local function init_noises()
 	if intialized then return end
-	intialized = false
+	intialized = true
 
 	n_height_select   = mgutils.get_noise("mgv7_np_height_select")
 	n_terrain_persist = mgutils.get_noise("mgv7_np_terrain_persist")

--- a/mgutils/mg_valleys.lua
+++ b/mgutils/mg_valleys.lua
@@ -54,7 +54,7 @@ local intialized = false
 
 local function init_noises()
 	if intialized then return end
-	intialized = false
+	intialized = true
 
 	n_rivers             = mgutils.get_noise("mgvalleys_np_rivers")
 	n_inter_valley_slope = mgutils.get_noise("mgvalleys_np_inter_valley_slope")


### PR DESCRIPTION
@pyrollo Don't feel like you need to merge this PR, it's more just to raise the issue.

And perhaps you'd prefer to solve this the way it's done in mg_v6.lua instead.